### PR TITLE
Use result of find_package(orocos_kdl) properly (#200)

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -14,13 +14,10 @@ find_package(TinyXML REQUIRED)
 include_directories(include ${orocos_kdl_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 link_directories(${catkin_LIBRARY_DIRS})
-link_directories(${orocos_kdl_LIBRARY_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
-find_library(KDL_LIBRARY REQUIRED NAMES orocos-kdl HINTS ${orocos_kdl_LIBRARY_DIRS})
-
 catkin_package(
-  LIBRARIES ${PROJECT_NAME} ${KDL_LIBRARY}
+  LIBRARIES ${PROJECT_NAME} ${orocos_kdl_LIBRARIES}
   INCLUDE_DIRS include
   CATKIN_DEPENDS roscpp rosconsole urdf
   DEPENDS orocos_kdl TinyXML


### PR DESCRIPTION
This is a cherry-pick of ros/robot_model#200 onto the indigo branch

1orocos_kdl_LIBRARY_DIRS1 was removed by https://github.com/orocos/orocos_kinematics_dynamics/commit/e2e2d6f4164c7e7731a36d80c4c0d26a0dedf668 in November 2013, 7ish months before Indigo was released. 