### PR TITLE
kdl_parser: switch from TinyXML to TinyXML2

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -9,9 +9,9 @@ find_package(catkin REQUIRED
   COMPONENTS roscpp rosconsole urdf cmake_modules
 )
 find_package(orocos_kdl REQUIRED)
-find_package(TinyXML REQUIRED)
+find_package(TinyXML2 REQUIRED)
 
-include_directories(include ${orocos_kdl_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include ${orocos_kdl_INCLUDE_DIRS} ${TinyXML2_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 link_directories(${catkin_LIBRARY_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
@@ -22,12 +22,12 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME} ${orocos_kdl_LIBRARIES}
   INCLUDE_DIRS include
   CATKIN_DEPENDS roscpp rosconsole urdf
-  DEPENDS orocos_kdl TinyXML
+  DEPENDS orocos_kdl TinyXML2
 )
 
 add_library(${PROJECT_NAME} src/kdl_parser.cpp)
 target_link_libraries(${PROJECT_NAME}
-  ${TinyXML_LIBRARIES} ${orocos_kdl_LIBRARIES} ${catkin_LIBRARIES}
+  ${TinyXML2_LIBRARIES} ${orocos_kdl_LIBRARIES} ${catkin_LIBRARIES}
 )
 
 add_executable(check_kdl_parser src/check_kdl_parser.cpp )

--- a/kdl_parser/include/kdl_parser/kdl_parser.hpp
+++ b/kdl_parser/include/kdl_parser/kdl_parser.hpp
@@ -40,7 +40,7 @@
 #include <kdl/tree.hpp>
 #include <string>
 #include <urdf_model/model.h>
-#include <tinyxml.h>
+#include <tinyxml2.h>
 
 namespace kdl_parser{
 
@@ -65,12 +65,12 @@ bool treeFromParam(const std::string& param, KDL::Tree& tree);
  */
 bool treeFromString(const std::string& xml, KDL::Tree& tree);
 
-/** Constructs a KDL tree from a TiXmlDocument
- * \param xml_doc The TiXmlDocument containting the xml description of the robot
+/** Constructs a KDL tree from a XMLDocument
+ * \param xml_doc The XMLDocument containting the xml description of the robot
  * \param tree The resulting KDL Tree
  * returns true on success, false on failure
  */
-bool treeFromXml(TiXmlDocument *xml_doc, KDL::Tree& tree);
+bool treeFromXml(tinyxml2::XMLDocument *xml_doc, KDL::Tree& tree);
 
 /** Constructs a KDL tree from a URDF robot model
  * \param robot_model The URDF robot model

--- a/kdl_parser/src/kdl_parser.cpp
+++ b/kdl_parser/src/kdl_parser.cpp
@@ -42,6 +42,7 @@
 
 using namespace std;
 using namespace KDL;
+using namespace tinyxml2;
 
 namespace kdl_parser{
 
@@ -155,8 +156,8 @@ bool addChildrenToTree(urdf::LinkConstSharedPtr root, Tree& tree)
 
 bool treeFromFile(const string& file, Tree& tree)
 {
-  TiXmlDocument urdf_xml;
-  urdf_xml.LoadFile(file);
+  XMLDocument urdf_xml;
+  urdf_xml.LoadFile(file.c_str());
   return treeFromXml(&urdf_xml, tree);
 }
 
@@ -172,12 +173,12 @@ bool treeFromParam(const string& param, Tree& tree)
 
 bool treeFromString(const string& xml, Tree& tree)
 {
-  TiXmlDocument urdf_xml;
+  XMLDocument urdf_xml;
   urdf_xml.Parse(xml.c_str());
   return treeFromXml(&urdf_xml, tree);
 }
 
-bool treeFromXml(TiXmlDocument *xml_doc, Tree& tree)
+bool treeFromXml(XMLDocument *xml_doc, Tree& tree)
 {
   urdf::Model robot_model;
   if (!robot_model.initXml(xml_doc)){


### PR DESCRIPTION
The library TinyXML is considered to be unmaintained and
since all future development is focused on TinyXML2 this
patch updates kdl_parser to use TinyXML2.

depends on https://github.com/ros/robot_model/pull/205