### PR TITLE
Remove the declaration of a library from kdl_parser_py.

### DIFF
--- a/kdl_parser_py/CMakeLists.txt
+++ b/kdl_parser_py/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(kdl_parser_py)
 
-find_package(catkin REQUIRED
-  COMPONENTS urdfdom_py
-)
+find_package(catkin REQUIRED)
 
 catkin_package(
   CATKIN_DEPENDS urdfdom_py

--- a/kdl_parser_py/CMakeLists.txt
+++ b/kdl_parser_py/CMakeLists.txt
@@ -3,12 +3,11 @@ cmake_minimum_required(VERSION 2.8.3)
 project(kdl_parser_py)
 
 find_package(catkin REQUIRED
-  COMPONENTS urdf
+  COMPONENTS urdfdom_py
 )
 
 catkin_package(
-  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS urdf
+  CATKIN_DEPENDS urdfdom_py
 )
 
 catkin_python_setup()

--- a/kdl_parser_py/package.xml
+++ b/kdl_parser_py/package.xml
@@ -29,12 +29,6 @@
   <build_export_depend>urdfdom_py</build_export_depend>
   <build_export_depend>python_orocos_kdl</build_export_depend>
 
-  <!-- The build_depend on urdfdom_py is needed for the doc job; we
-       don't have one for python_orocos_kdl because it is not a
-       catkin package.
-  -->
-  <build_depend>urdfdom_py</build_depend>
-
   <exec_depend>urdfdom_py</exec_depend>
   <exec_depend>python_orocos_kdl</exec_depend>
 

--- a/kdl_parser_py/package.xml
+++ b/kdl_parser_py/package.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <package format="2">
   <name>kdl_parser_py</name>
   <version>1.13.0</version>
@@ -27,6 +28,12 @@
 
   <build_export_depend>urdfdom_py</build_export_depend>
   <build_export_depend>python_orocos_kdl</build_export_depend>
+
+  <!-- The build_depend on urdfdom_py is needed for the doc job; we
+       don't have one for python_orocos_kdl because it is not a
+       catkin package.
+  -->
+  <build_depend>urdfdom_py</build_depend>
 
   <exec_depend>urdfdom_py</exec_depend>
   <exec_depend>python_orocos_kdl</exec_depend>


### PR DESCRIPTION
It does not install a library, so it shouldn't declare it here.
Also fix up the dependencies to be more correct, since it really
requires urdfdom_py, not urdf.  It also needs a <build_depend>
on urdfdom_py now.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>