### PR TITLE
resolved real minor py3 conflict with KDL

### DIFF
--- a/kdl_parser_py/kdl_parser_py/urdf.py
+++ b/kdl_parser_py/kdl_parser_py/urdf.py
@@ -50,7 +50,7 @@ def _toKdlInertia(i):
 
 def _toKdlJoint(jnt):
 
-    fixed = lambda j,F: kdl.Joint(j.name, kdl.Joint.None)
+    fixed = lambda j,F: kdl.Joint(j.name, getattr(kdl.Joint, 'None'))
     rotational = lambda j,F: kdl.Joint(j.name, F.p, F.M * kdl.Vector(*j.axis), kdl.Joint.RotAxis)
     translational = lambda j,F: kdl.Joint(j.name, F.p, F.M * kdl.Vector(*j.axis), kdl.Joint.TransAxis)
 
@@ -122,5 +122,5 @@ def treeFromUrdfModel(robot_model, quiet=False):
         if not _add_children_to_tree(robot_model, robot_model.link_map[child], tree):
             ok = False
             break
-  
+
     return (ok, tree)


### PR DESCRIPTION
This is a super minor request to be adjusted. But I ran into this issue by this afternoon, as python3 does not allow None as an attribute of a class (for good reasons :smile:). 
In case the py3 problems lies on my side, ignore this request.