### PR TITLE
correct DEPRECATED helper macro

### DIFF
--- a/kdl_parser/include/kdl_parser/visibility_control.hpp
+++ b/kdl_parser/include/kdl_parser/visibility_control.hpp
@@ -45,15 +45,15 @@
 // This logic was borrowed (then namespaced) from the examples on the gcc wiki:
 //     https://gcc.gnu.org/wiki/Visibility
 
-#define KDL_PARSER_DEPRECATED(msg) __attribute__((deprecated(msg)))
-
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef __GNUC__
     #define KDL_PARSER_EXPORT __attribute__ ((dllexport))
     #define KDL_PARSER_IMPORT __attribute__ ((dllimport))
+    #define KDL_PARSER_DEPRECATED(msg) __attribute__((deprecated(msg)))
   #else
     #define KDL_PARSER_EXPORT __declspec(dllexport)
     #define KDL_PARSER_IMPORT __declspec(dllimport)
+	#define KDL_PARSER_DEPRECATED(msg)
   #endif
   #ifdef KDL_PARSER_BUILDING_DLL
     #define KDL_PARSER_PUBLIC KDL_PARSER_EXPORT
@@ -73,6 +73,7 @@
     #define KDL_PARSER_LOCAL
   #endif
   #define KDL_PARSER_PUBLIC_TYPE
+  #define KDL_PARSER_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #endif
 
 #endif  // KDL_PARSER__VISIBILITY_CONTROL_HPP_

--- a/kdl_parser/include/kdl_parser/visibility_control.hpp
+++ b/kdl_parser/include/kdl_parser/visibility_control.hpp
@@ -53,7 +53,7 @@
   #else
     #define KDL_PARSER_EXPORT __declspec(dllexport)
     #define KDL_PARSER_IMPORT __declspec(dllimport)
-	#define KDL_PARSER_DEPRECATED(msg)
+    #define KDL_PARSER_DEPRECATED(msg) __declspec(deprecated(msg))
   #endif
   #ifdef KDL_PARSER_BUILDING_DLL
     #define KDL_PARSER_PUBLIC KDL_PARSER_EXPORT


### PR DESCRIPTION
correct `DEPRECATED` helper macro on Windows to use `__declspec(deprecated(msg))`