### PR TITLE
Fix check of sys.argv length.

### DIFF
--- a/kdl_parser_py/test/test_kdl_parser.py
+++ b/kdl_parser_py/test/test_kdl_parser.py
@@ -13,7 +13,7 @@ NAME = "test_kdl_parser"
 class TestKdlParser(unittest.TestCase):
     def runTest(self):
         filename = None
-        if (sys.argv > 1):
+        if (len(sys.argv) > 1):
             filename = sys.argv[1]
         else:
             self.fail("Expected filename!")


### PR DESCRIPTION
We needed to call len(sys.argv)

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@sloretz FYI