### PR TITLE
noetic release

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(kdl_parser)
 

--- a/kdl_parser_py/CMakeLists.txt
+++ b/kdl_parser_py/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(kdl_parser_py)
 

--- a/kdl_parser_py/package.xml
+++ b/kdl_parser_py/package.xml
@@ -24,6 +24,8 @@
   <url type="bugtracker">https://github.com/ros/kdl_parser/issues</url>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</buildtool_depend>
 

--- a/kdl_parser_py/setup.py
+++ b/kdl_parser_py/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/kdl_parser_py/setup.py
+++ b/kdl_parser_py/setup.py
@@ -4,8 +4,7 @@ from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-   packages=['kdl_parser_py'],
-   package_dir={'': ''}
+   packages=['kdl_parser_py']
 )
 
 setup(**d)


### PR DESCRIPTION

-  Use setuptools instead of distutils 

Since ros/catkin#1048 catkin prefers to use setuptools instead of distutils. The package.xml doesn't need to include python3-setuptools because [catkin exports that dependency](https://github.com/ros/catkin/blob/86439ec5d2010d5c47c30b815aa97e525037930f/package.xml#L32) for the convenience of all downstream python packages.

-  Bump CMake version to avoid CMP0048

This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.