### PR TITLE
Set C++ standard to 14

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.7.2)
 
 project(kdl_parser)
 

--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.7.2)
 
 project(kdl_parser)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(catkin QUIET
   COMPONENTS rosconsole cmake_modules
 )
@@ -34,8 +37,6 @@ if(urdf_FOUND)
 endif()
 
 include_directories(include ${orocos_kdl_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${TinyXML2_INCLUDE_DIRS})
-
-add_compile_options(-std=c++11)
 
 if(catkin_FOUND)
   link_directories(${catkin_LIBRARY_DIRS})


### PR DESCRIPTION
Alternative to #24. I bumped the CMake version to `3.7.2` because it's the minimum supported by ROS Melodic; though the minimum version for `CMAKE_CXX_STANDARD` appears to be 3.1 .