### PR TITLE
Used keys for Orocos

### DIFF
--- a/kdl_parser/package.xml
+++ b/kdl_parser/package.xml
@@ -22,7 +22,7 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <depend version_gte="1.3.0">orocos_kdl</depend>
+  <depend version_gte="1.3.0">liborocos-kdl-dev</depend>
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>

--- a/kdl_parser_py/package.xml
+++ b/kdl_parser_py/package.xml
@@ -30,10 +30,10 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</buildtool_depend>
 
   <build_export_depend>urdfdom_py</build_export_depend>
-  <build_export_depend>python_orocos_kdl</build_export_depend>
+  <build_export_depend>python3-pykdl</build_export_depend>
 
   <exec_depend>urdfdom_py</exec_depend>
-  <exec_depend>python_orocos_kdl</exec_depend>
+  <exec_depend>python3-pykdl</exec_depend>
 
   <test_depend>rostest</test_depend>
 

--- a/kdl_parser_py/package.xml
+++ b/kdl_parser_py/package.xml
@@ -30,7 +30,6 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</buildtool_depend>
 
   <build_export_depend>urdfdom_py</build_export_depend>
-  <build_export_depend>python3-pykdl</build_export_depend>
 
   <exec_depend>urdfdom_py</exec_depend>
   <exec_depend>python3-pykdl</exec_depend>


### PR DESCRIPTION
With this PR https://github.com/ros/rosdistro/pull/23841/files Orokos could be installed via `rosdep`

