### PR TITLE
Remove unused find_library call

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -8,9 +8,6 @@ find_package(tinyxml_vendor REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(urdf REQUIRED)
 find_package(urdfdom_headers REQUIRED)
-find_library(KDL_LIBRARY REQUIRED
-  NAMES orocos-kdl
-  HINTS ${orocos_kdl_LIBRARY_DIRS})
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)


### PR DESCRIPTION
This is to address recent failures in the nightly Windows debug builds.

It is likely related to a recent version upgrade in CMake, which is now 3.18.0 in Chocolatey.

Signed-off-by: Michael Carroll <michael@openrobotics.org>