### PR TITLE
[dashing] Remove unused find_library call (#40)

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -8,9 +8,6 @@ find_package(tinyxml_vendor REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(urdf REQUIRED)
 find_package(urdfdom_headers REQUIRED)
-find_library(KDL_LIBRARY REQUIRED
-  NAMES orocos-kdl
-  HINTS ${orocos_kdl_LIBRARY_DIRS})
 
 include_directories(
   include


### PR DESCRIPTION
Since dashing is also impacted by the cmake updates on Windows.

Signed-off-by: Michael Carroll <michael@openrobotics.org>