### PR TITLE
Remove tinyxml dependency from kdl_parser.

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -4,8 +4,6 @@ project(kdl_parser)
 
 find_package(ament_cmake_ros REQUIRED)
 find_package(orocos_kdl REQUIRED)
-find_package(tinyxml_vendor REQUIRED)
-find_package(TinyXML REQUIRED)
 find_package(urdf REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 
@@ -23,7 +21,6 @@ target_include_directories(${PROJECT_NAME}
   "$<INSTALL_INTERFACE:include>"
 )
 ament_target_dependencies(${PROJECT_NAME}
-  TinyXML
   orocos_kdl
   urdf
   urdfdom_headers)

--- a/kdl_parser/include/kdl_parser/kdl_parser.hpp
+++ b/kdl_parser/include/kdl_parser/kdl_parser.hpp
@@ -38,7 +38,6 @@
 #define KDL_PARSER__KDL_PARSER_HPP_
 
 #include <string>
-#include <tinyxml.h>  // NOLINT
 
 #include "kdl/tree.hpp"
 #include "urdf_model/model.h"
@@ -56,14 +55,6 @@ namespace kdl_parser
 KDL_PARSER_PUBLIC
 bool treeFromFile(const std::string & file, KDL::Tree & tree);
 
-/** Constructs a KDL tree from the parameter server, given the parameter name
- * \param param the name of the parameter on the parameter server
- * \param tree The resulting KDL Tree
- * returns true on success, false on failure
- */
-KDL_PARSER_PUBLIC
-bool treeFromParam(const std::string & param, KDL::Tree & tree);
-
 /** Constructs a KDL tree from a string containing xml
  * \param xml A string containting the xml description of the robot
  * \param tree The resulting KDL Tree
@@ -71,15 +62,6 @@ bool treeFromParam(const std::string & param, KDL::Tree & tree);
  */
 KDL_PARSER_PUBLIC
 bool treeFromString(const std::string & xml, KDL::Tree & tree);
-
-/** Constructs a KDL tree from a TiXmlDocument
- * \param xml_doc The TiXmlDocument containting the xml description of the robot
- * \param tree The resulting KDL Tree
- * returns true on success, false on failure
- */
-[[deprecated("Use treeFromString instead")]]
-KDL_PARSER_PUBLIC
-bool treeFromXml(TiXmlDocument * xml_doc, KDL::Tree & tree);
 
 /** Constructs a KDL tree from a URDF robot model
  * \param robot_model The URDF robot model

--- a/kdl_parser/package.xml
+++ b/kdl_parser/package.xml
@@ -24,13 +24,9 @@
 
   <depend version_gte="1.3.0">orocos_kdl</depend>
 
-  <build_depend>tinyxml</build_depend>
-  <build_depend>tinyxml_vendor</build_depend>
   <build_depend>urdf</build_depend>
   <build_depend>urdfdom_headers</build_depend>
 
-  <exec_depend>tinyxml</exec_depend>
-  <exec_depend>tinyxml_vendor</exec_depend>
   <exec_depend>urdf</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/kdl_parser/src/kdl_parser.cpp
+++ b/kdl_parser/src/kdl_parser.cpp
@@ -167,20 +167,6 @@ bool treeFromFile(const std::string & file, KDL::Tree & tree)
   return treeFromString(buffer.str(), tree);
 }
 
-bool treeFromParam(const std::string & param, KDL::Tree & tree)
-{
-  fprintf(stderr, "treeFromParam currently not implemented.\n");
-  return false;
-  /*
-  urdf::Model robot_model;
-  if (!robot_model.initParam(param)){
-    ROS_ERROR("Could not generate robot model");
-    return false;
-  }
-  return treeFromUrdfModel(robot_model, tree);
-  */
-}
-
 bool treeFromString(const std::string & xml, KDL::Tree & tree)
 {
   urdf::Model robot_model;
@@ -190,14 +176,6 @@ bool treeFromString(const std::string & xml, KDL::Tree & tree)
   }
   return treeFromUrdfModel(robot_model, tree);
 }
-
-bool treeFromXml(TiXmlDocument * xml_doc, KDL::Tree & tree)
-{
-  std::stringstream ss;
-  ss << *xml_doc;
-  return treeFromString(ss.str(), tree);
-}
-
 
 bool treeFromUrdfModel(const urdf::ModelInterface & robot_model, KDL::Tree & tree)
 {


### PR DESCRIPTION
It was deprecated in Foxy, and we can now remove it for Galactic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>