### PR TITLE
Restored compatibility with Orocos KDL after Joint.None was removed

### DIFF
--- a/kdl_parser_py/kdl_parser_py/urdf.py
+++ b/kdl_parser_py/kdl_parser_py/urdf.py
@@ -50,7 +50,9 @@ def _toKdlInertia(i):
 
 def _toKdlJoint(jnt):
 
-    fixed = lambda j,F: kdl.Joint(j.name, getattr(kdl.Joint, 'None'))
+    fixed = lambda j,F: kdl.Joint(
+        j.name,
+        getattr(kdl.Joint, 'Fixed') if hasattr(kdl.Joint, 'Fixed') else getattr(kdl.Joint, 'None'))
     rotational = lambda j,F: kdl.Joint(j.name, F.p, F.M * kdl.Vector(*j.axis), kdl.Joint.RotAxis)
     translational = lambda j,F: kdl.Joint(j.name, F.p, F.M * kdl.Vector(*j.axis), kdl.Joint.TransAxis)
 


### PR DESCRIPTION
https://github.com/orocos/orocos_kinematics_dynamics/commit/d518c8b86e2be19fc1389fda91c9f566c21c0b8c removed attribute `PyKDL.Joint.None`. With this PR, compatibility is ensured, preferring `PyKDL.Joint.Fixed` and only falling back to `PyKDL.Joint.None` if the former is no attribute of `PyKDL.Joint`. See discussion in https://github.com/ros/kdl_parser/issues/44.