### PR TITLE
Use DEBUG log level when listing link children message

### DIFF
--- a/kdl_parser/src/kdl_parser.cpp
+++ b/kdl_parser/src/kdl_parser.cpp
@@ -126,7 +126,7 @@ KDL::RigidBodyInertia toKdl(urdf::InertialSharedPtr i)
 bool addChildrenToTree(urdf::LinkConstSharedPtr root, KDL::Tree & tree)
 {
   std::vector<urdf::LinkSharedPtr> children = root->child_links;
-  RCUTILS_LOG_INFO_NAMED(
+  RCUTILS_LOG_DEBUG_NAMED(
     "kdl_parser",
     "Link %s had %zu children.", root->name.c_str(), children.size());
 


### PR DESCRIPTION
[In the `noetic-devel` branch](https://github.com/ros/kdl_parser/blob/74d4ee3bc6938de8ae40a700997baef06114ea1b/kdl_parser/src/kdl_parser.cpp#L145), this message is printed using `ROS_DEBUG`. This changes the ROS2 version to use the equivalent `RCUTILS_LOG_DEBUG_NAMED` macro.
