### PR TITLE
Backport rcutils logger fix to Humble

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(orocos_kdl_vendor REQUIRED)
 find_package(orocos_kdl REQUIRED)
 find_package(urdf REQUIRED)
 find_package(urdfdom_headers REQUIRED)
+find_package(rcutils REQUIRED)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
@@ -24,6 +25,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   orocos-kdl
   urdfdom_headers::urdfdom_headers)
 target_link_libraries(${PROJECT_NAME} PRIVATE
+  rcutils::rcutils
   urdf::urdf)
 
 if(WIN32)
@@ -48,6 +50,7 @@ endif()
 
 ament_export_dependencies(orocos_kdl_vendor)
 ament_export_dependencies(orocos_kdl)
+ament_export_dependencies(rcutils)
 ament_export_dependencies(urdfdom_headers)
 ament_export_targets(export_${PROJECT_NAME})
 ament_package()

--- a/kdl_parser/package.xml
+++ b/kdl_parser/package.xml
@@ -23,6 +23,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>orocos_kdl_vendor</depend>
+  <depend>rcutils</depend>
 
   <build_depend>urdf</build_depend>
   <build_depend>urdfdom_headers</build_depend>

--- a/kdl_parser/src/kdl_parser.cpp
+++ b/kdl_parser/src/kdl_parser.cpp
@@ -132,7 +132,7 @@ KDL::RigidBodyInertia toKdl(urdf::InertialSharedPtr i)
 bool addChildrenToTree(urdf::LinkConstSharedPtr root, KDL::Tree & tree)
 {
   std::vector<urdf::LinkSharedPtr> children = root->child_links;
-  RCUTILS_LOG_INFO_NAMED(
+  RCUTILS_LOG_DEBUG_NAMED(
     "kdl_parser",
     "Link %s had %zu children.", root->name.c_str(), children.size());
 

--- a/kdl_parser/src/kdl_parser.cpp
+++ b/kdl_parser/src/kdl_parser.cpp
@@ -42,6 +42,8 @@
 #include "kdl/frames_io.hpp"
 #include "urdf/model.h"
 #include "urdf/urdfdom_compatibility.h"
+#include "rcutils/logging_macros.h"
+
 
 namespace kdl_parser
 {
@@ -86,9 +88,9 @@ KDL::Joint toKdl(urdf::JointSharedPtr jnt)
         return KDL::Joint(jnt->name, F_parent_jnt.p, F_parent_jnt.M * axis, KDL::Joint::TransAxis);
       }
     default: {
-        fprintf(
-          stderr, "Converting unknown joint type of joint '%s' into a fixed joint\n",
-          jnt->name.c_str());
+        RCUTILS_LOG_WARN_NAMED(
+          "kdl_parser",
+          "Converting unknown joint type of joint '%s' into a fixed joint", jnt->name.c_str());
         return KDL::Joint(jnt->name, KDL::Joint::None);
       }
   }
@@ -130,7 +132,9 @@ KDL::RigidBodyInertia toKdl(urdf::InertialSharedPtr i)
 bool addChildrenToTree(urdf::LinkConstSharedPtr root, KDL::Tree & tree)
 {
   std::vector<urdf::LinkSharedPtr> children = root->child_links;
-  fprintf(stderr, "Link %s had %zu children\n", root->name.c_str(), children.size());
+  RCUTILS_LOG_INFO_NAMED(
+    "kdl_parser",
+    "Link %s had %zu children.", root->name.c_str(), children.size());
 
   // constructs the optional inertia
   KDL::RigidBodyInertia inert(0);
@@ -171,7 +175,7 @@ bool treeFromString(const std::string & xml, KDL::Tree & tree)
 {
   urdf::Model robot_model;
   if (!robot_model.initString(xml.c_str())) {
-    fprintf(stderr, "Could not generate robot model\n");
+    RCUTILS_LOG_ERROR_NAMED("kdl_parser", "Could not generate robot model.");
     return false;
   }
   return treeFromUrdfModel(robot_model, tree);
@@ -187,10 +191,11 @@ bool treeFromUrdfModel(const urdf::ModelInterface & robot_model, KDL::Tree & tre
 
   // warn if root link has inertia. KDL does not support this
   if (robot_model.getRoot()->inertial) {
-    fprintf(
-      stderr, "The root link %s has an inertia specified in the URDF, but KDL does not "
-      "support a root link with an inertia.  As a workaround, you can add an extra "
-      "dummy link to your URDF.\n", robot_model.getRoot()->name.c_str());
+    RCUTILS_LOG_WARN_NAMED(
+      "kdl_parser",
+      "The root link %s has an inertia specified in the URDF, but KDL "
+      "does not support a root link with an inertia.  As a workaround, you can add "
+      "an extra dummy link to your URDF.", robot_model.getRoot()->name.c_str());
   }
 
   //  add all children


### PR DESCRIPTION
Applies the changes from #65 (plus my additional fix from #71) to the `humble` branch.