### PR TITLE
fix{cmakelists}: fix no catkin installation path

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -98,5 +98,5 @@ else()
           LIBRARY DESTINATION lib
           ARCHIVE DESTINATION lib)
   install(DIRECTORY include/${PROJECT_NAME}/
-          DESTINATION include)
+          DESTINATION include/${PROJECT_NAME}/)
 endif()


### PR DESCRIPTION
This PR modifies the CMakeLists.txt to have the same behaviour when the package is installed either using catkin or not.

In this way, the package is fully functional with and without the ROS environment installed.

The folder has been set to : `include/${PROJECT_NAME}/` in both cases.