### PR TITLE
Fix missing optional axis element

### DIFF
--- a/kdl_parser_py/kdl_parser_py/urdf.py
+++ b/kdl_parser_py/kdl_parser_py/urdf.py
@@ -49,7 +49,8 @@ def _toKdlInertia(i):
             kdl.RotationalInertia(inertia.ixx, inertia.iyy, inertia.izz, inertia.ixy, inertia.ixz, inertia.iyz));
 
 def _toKdlJoint(jnt):
-
+    if jnt.axis is None:
+        jnt.axis = [1., 0., 0.]
     fixed = lambda j,F: kdl.Joint(
         j.name,
         getattr(kdl.Joint, 'Fixed') if hasattr(kdl.Joint, 'Fixed') else getattr(kdl.Joint, 'None'))


### PR DESCRIPTION
The <axis> element is actually optional in URDFs, see http://wiki.ros.org/urdf/XML/joint. This PR sets the axis to the default value (1,0,0) if it is not set in the URDF.